### PR TITLE
stronger typing and improved docstrings for W&B file

### DIFF
--- a/training/wab.py
+++ b/training/wab.py
@@ -2,8 +2,11 @@
 import argparse
 import os
 from pathlib import Path
+from typing import Any
 
 import wandb
+from wandb import Artifact
+from wandb.sdk.wandb_run import Run
 
 
 # Variables
@@ -22,12 +25,14 @@ api = wandb.Api()
 DEFAULT_ENTITY = api.default_entity
 
 
-def get_logging_run(artifact):
+def get_logging_run(artifact: Artifact) -> Run:
+    """Get the W&B run that logged the artifact"""
     api_run = artifact.logged_by()
     return api_run
 
 
-def print_info(artifact, run=None):
+def print_info(artifact: Artifact, run=None) -> None:
+    """Prints info about the artifact and the run"""
     run = get_logging_run(artifact)
 
     full_artifact_name = f"{artifact.entity}/{artifact.project}/{artifact.name}"
@@ -40,18 +45,18 @@ def print_info(artifact, run=None):
     print(f"View at URL: {run.url}")
 
 
-def download_artifact(artifact_path):
+def download_artifact(artifact_path: str) -> Artifact:
     """Downloads the artifact at artifact_path to the target directory."""
     if wandb.run is not None:  # if we are inside a W&B run, track that we used this artifact
-        artifact = wandb.use_artifact(artifact_path)
+        artifact: Artifact = wandb.use_artifact(artifact_path)
     else:  # otherwise, just download the artifact via the API
-        artifact = api.artifact(artifact_path)
+        artifact: Artifact = api.artifact(artifact_path)
     artifact.download(root=PROD_STAGING_ROOT)
 
     return artifact
 
 
-def setup(fetch, override):
+def setup(fetch, override) -> Any:
     # If overriding, remove local files; otherwise, make sure local files do not match all W&B files
     if fetch:
         if override:
@@ -62,7 +67,8 @@ def setup(fetch, override):
                 return
 
 
-def upload_staged_model(staged_at):
+def upload_staged_model(staged_at: Artifact) -> None:
+    """Uploads a staged arfifact to W&B"""
     staged_at.add_dir(PROD_STAGING_ROOT)
     wandb.log_artifact(staged_at)
 


### PR DESCRIPTION
We talked a bit about typing at the start of the project and I did this while I was getting familiar with W&B setup.

So basically I added explicitly types for some variables which VSCode can interpret. For example, if you hover over "Artifact"-typed variables, you will see some description of it and if you type a "." after it, the IDE will also suggest you some methods. 

This way of writing code improves the readability of the code a whole ton and I think we should try to write the rest of the code in this style and we can also modify the old code when we have to modify.

What do you think about this?

PS: You can usually find these types from the package documentations, for example [here](https://docs.wandb.ai/ref/python/artifact) for W&B Artifacts. It shows you, i.e.:
- The attributes and their types of the class
- The class methods, their parameters and the method return types