### PR TITLE
Gpt 3 answer improvement

### DIFF
--- a/question_answer/answer.py
+++ b/question_answer/answer.py
@@ -183,17 +183,17 @@ class PICa_OKVQA:
                         temperature=0.0,
                         stream=False,
                         stop=["\n", "<|endoftext|>"],
-                    )
+                    )["choices"][0]
                 except Exception as e:
                     print(e)
                     exit(0)
 
                 plist = []
-                for ii in range(len(response["choices"][0]["logprobs"]["tokens"])):
-                    if response["choices"][0]["logprobs"]["tokens"][ii] == "\n":
+                for ii in range(len(response["logprobs"]["tokens"])):
+                    if response["logprobs"]["tokens"][ii] == "\n":
                         break
-                    plist.append(response["choices"][0]["logprobs"]["token_logprobs"][ii])
-                pred_answer_list.append(self.process_answer(response["choices"][0]["text"]))
+                    plist.append(response["logprobs"]["token_logprobs"][ii])
+                pred_answer_list.append(self.process_answer(response["text"]))
                 pred_prob_list.append(sum(plist))
             maxval = -999.0
             for ii in range(len(pred_prob_list)):

--- a/question_answer/answer.py
+++ b/question_answer/answer.py
@@ -178,9 +178,9 @@ class PICa_OKVQA:
                     response = openai.Completion.create(
                         engine=engine,
                         prompt=prompt,
-                        max_tokens=5,
+                        max_tokens=80,
                         logprobs=1,
-                        temperature=0.0,
+                        temperature=0.7,
                         stream=False,
                         stop=["\n", "<|endoftext|>"],
                     )["choices"][0]
@@ -195,6 +195,8 @@ class PICa_OKVQA:
                     plist.append(response["logprobs"]["token_logprobs"][ii])
                 pred_answer_list.append(self.process_answer(response["text"]))
                 pred_prob_list.append(sum(plist))
+                
+            # Choose the prediction with highest log probs
             maxval = -999.0
             for ii in range(len(pred_prob_list)):
                 if pred_prob_list[ii] > maxval:

--- a/question_answer/answer.py
+++ b/question_answer/answer.py
@@ -152,7 +152,7 @@ class PICa_OKVQA:
 
             for repeat in range(n_ensemble):
                 # prompt format following GPT-3 QA API
-                prompt = "Please answer the question according to the above context.\n===\n"
+                prompt = "Answer the question according to the given context.\n===\n"
                 for ni in range(n_shot):
                     if context_key_list is None:
                         context_key = self.train_keys[random.randint(0, len(self.train_keys) - 1)]
@@ -167,12 +167,12 @@ class PICa_OKVQA:
                             break
                         context_key = self.train_keys[random.randint(0, len(self.train_keys) - 1)]
                     prompt += "Context: %s\n===\n" % self.traincontext_caption_dict[img_context_key]
-                    prompt += "Q: %s\nA: %s\n\n===\n" % (
+                    prompt += "Question: %s\nAnswer: %s\n\n===\n" % (
                         self.traincontext_question_dict[context_key],
                         self.traincontext_answer_dict[context_key],
                     )
                 prompt += "Context: %s\n===\n" % caption
-                prompt += "Q: %s\nA:" % question
+                prompt += "Question: %s\nAnswer:" % question
                 response = None
                 try:
                     response = openai.Completion.create(


### PR DESCRIPTION
Some small improvements to GPT-3 prompts and parameters. These are not tested in this project but these are something I found to help in previous projects.

- More verbose and straight-forward prompt: for example, instead of "a", we use "answer"
- Increase token count: 80 is not necessarily the best number but 5 makes it so the answer might get cut off early even if GPT-3 would like to give a longer, more verbose response
- Increase temperature: again, there is not an exact correct answer to this, to some extent it's trial and error. But 0 temperature more often outputs garbage than higher temperatures because it has a higher tendency to repeat the same text. 0.7 has been a good middle ground between correct and varied text.